### PR TITLE
Kanban

### DIFF
--- a/client/src/app/dashboard/dashboard.component.ts
+++ b/client/src/app/dashboard/dashboard.component.ts
@@ -36,6 +36,9 @@ export class DashboardComponent implements OnInit {
   }
 
   markCompleted(task: Todo): void {
+    if (this.taskService.isKanbanTask(task)){
+      this.taskService.syncKanbanCompleted(task);
+    }
     this.taskService.updateTodo(task).subscribe();
   }
 

--- a/client/src/app/kanban/kanban-category/kanban-category.component.ts
+++ b/client/src/app/kanban/kanban-category/kanban-category.component.ts
@@ -38,6 +38,7 @@ export class KanbanCategoryComponent implements OnInit {
   }
 
   updateCategory(task: Todo): void{
+    this.taskService.syncKanbanDone(task);
     this.taskService.updateTodo(task).subscribe(() => location.reload());
   }
 

--- a/client/src/app/services/task.service.ts
+++ b/client/src/app/services/task.service.ts
@@ -9,49 +9,49 @@ import { catchError, map } from 'rxjs/operators';
   providedIn: 'root'
 })
 export class TaskService {
-  url:string = 'http://3.15.237.3:8080/todos';
+  url: string = 'http://3.15.237.3:8080/todos';
 
   httpHeader = {
     headers: new HttpHeaders({
-      'Content-Type':'application/json',
+      'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*'
     })
   }
 
   constructor(private http: HttpClient) { }
 
-  addTodo(todo: Todo):Observable<any>{
-    return this.http.post<Todo>(this.url,todo,this.httpHeader);
+  addTodo(todo: Todo): Observable<any> {
+    return this.http.post<Todo>(this.url, todo, this.httpHeader);
   }
 
-  deleteTodo(todo: Todo):Observable<any>{
-    return this.http.delete(`${this.url}/${todo.id}`,this.httpHeader);
+  deleteTodo(todo: Todo): Observable<any> {
+    return this.http.delete(`${this.url}/${todo.id}`, this.httpHeader);
   }
 
-  findTodo(id:number):Observable<any>{
+  findTodo(id: number): Observable<any> {
     return this.http.get(`${this.url}/${id}`);
   }
-  
-  getTodos(): Observable<Todo[]>{
+
+  getTodos(): Observable<Todo[]> {
     return this.http.get<Todo[]>(this.url);
   }
 
 
-  updateTodo(todo: Todo): Observable<any> {  
-    return this.http.put(`${this.url}`,todo,this.httpHeader)
-  }  
+  updateTodo(todo: Todo): Observable<any> {
+    return this.http.put(`${this.url}`, todo, this.httpHeader)
+  }
 
   searchTodos(term: string): Observable<Todo[]> {
-    
+
     if (!term.trim()) {
       // if not search term, return empty todo array
-      return of([]);      
+      return of([]);
     }
-    
-    return this.http.get<Todo[]>(`${this.url}`).pipe(         
-      map(x => x.filter(t=> t.title.match(new RegExp(term,'gi')))),
+
+    return this.http.get<Todo[]>(`${this.url}`).pipe(
+      map(x => x.filter(t => t.title.match(new RegExp(term, 'gi')))),
       catchError(this.handleError<Todo[]>('searchTodos', []))
-    );   
+    );
   }
   private handleError<T>(operation = 'operation', result?: T) {
     return (error: any): Observable<T> => {
@@ -66,5 +66,36 @@ export class TaskService {
       return of(result as T);
     };
   } // end handleError method
+
+  //Kanban-related Services
+  isKanbanTask(task: Todo): boolean {
+    if (task.category === 'ToDo' ||
+      task.category === 'InProgress' ||
+      task.category === 'Done') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  syncKanbanCompleted(task: Todo): void {
+    if (task.completed) {
+      task.category = "Done";
+      this.updateTodo(task).subscribe();
+    } else {
+      task.category = "InProgress";
+      this.updateTodo(task).subscribe();
+    }
+  }
+
+  syncKanbanDone(task: Todo): void {
+    if (task.category === 'Done') {
+      task.completed = true;
+      this.updateTodo(task).subscribe();
+    } else {
+      task.completed = false;
+      this.updateTodo(task).subscribe();
+    }
+  }
 
 }

--- a/client/src/app/services/task.service.ts
+++ b/client/src/app/services/task.service.ts
@@ -78,7 +78,8 @@ export class TaskService {
     }
   }
 
-  syncKanbanCompleted(task: Todo): void {
+//Use to change the Category when Completed is changed
+  syncKanbanCompleted(task: Todo): void { 
     if (task.completed) {
       task.category = "Done";
       this.updateTodo(task).subscribe();
@@ -88,7 +89,8 @@ export class TaskService {
     }
   }
 
-  syncKanbanDone(task: Todo): void {
+  //Use to change the Completed flag when Category is changed
+  syncKanbanDone(task: Todo): void { 
     if (task.category === 'Done') {
       task.completed = true;
       this.updateTodo(task).subscribe();


### PR DESCRIPTION
Kanban Services added
Use "**this.taskService.isKanbanTask(task)**" to get a true/false based on Category
Use this before syncing so you don't accidentally turn a non-kanban task into a kanban task

Could only figure out how to do one-way checks, 
Use **this.taskService.syncKanbanCompleted(task)**; before your updateTodo when the completed checkmark is changed.
Use **this.taskService.syncKanbanDone(task)**; before updateTodo when the Category is changed, which should only be done on kanban-related pages.

If you can figure out how to detect if the checkbox and/or category was changed on a page that allows you to edit both, you can call one or the other based on what's changed (and whichever you think takes precedence if both are changed). 

Right now, the kanban-detail page should be the only page that allows you to un-sync these fields. As everything else should only allow either Completed changing or Kanban-related Category changing. I could potentially remove the ability to mark tasks as "Completed" on the kanban-detail page, since you really should just be marking them as "Done" anyway.
